### PR TITLE
Avoid photo stretching on DetailsPage

### DIFF
--- a/src/templates/DetailsPageStyles.css
+++ b/src/templates/DetailsPageStyles.css
@@ -15,6 +15,7 @@
 #imgDetailPage {
     width: 100%;
     height: 550px;
+    object-fit: contain;
 }
 
 .details-content span {


### PR DESCRIPTION
Currently, the animal photo on `DetailsPage` is stretched with the wrong aspect ratio:
![image](https://user-images.githubusercontent.com/1113976/85268811-ecc5a700-b46e-11ea-9287-fb96c4c836fe.png)

By adding this change, the photo becomes more clear:
![image](https://user-images.githubusercontent.com/1113976/85268888-049d2b00-b46f-11ea-8d7e-13250d8b7f0e.png)
